### PR TITLE
Custom define `lexicographical_compare_three_way` for Android builds

### DIFF
--- a/oxenc/common.h
+++ b/oxenc/common.h
@@ -76,7 +76,7 @@ concept const_contiguous_range_t =
 
 using namespace std::literals;
 
-#if !defined(_LIBCPP_VERSION) || _LIBCPP_VERSION >= 170000
+#if !defined(ANDROID) && (!defined(_LIBCPP_VERSION) || _LIBCPP_VERSION >= 170000)
 using std::lexicographical_compare_three_way;
 #else
 template <class InputIterator1, class InputIterator2, class Cmp>


### PR DESCRIPTION
There is a build issue with the "Static Android" build of `libSession` - it seems the latest version of oxen-encoding uses a function which the Android NDK doesn't support so we need to use our custom implementation for Android builds instead