### PR TITLE
hex/b32z/b64 literals: fixed-extent, better diagnostics

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@ if(CCACHE_PROGRAM)
 endif()
 
 project(oxenc
-    VERSION 1.5.1
+    VERSION 1.6.0
     DESCRIPTION "oxenc - Base 16/32/64 and Bittorrent Encoding/Decoding Header Only Library"
     LANGUAGES CXX)
 

--- a/oxenc/base32z.h
+++ b/oxenc/base32z.h
@@ -349,21 +349,21 @@ namespace detail {
 
 inline namespace literals {
     template <detail::c_b32z_literal Base32z>
+        requires(Base32z.valid)
     constexpr std::string_view operator""_b32z() {
-        static_assert(Base32z.valid, "invalid base32z literal");
         return {Base32z.decoded, Base32z.size};
     }
 
     template <detail::b_b32z_literal Base32z>
-    constexpr std::span<const std::byte> operator""_b32z_b() {
-        static_assert(Base32z.valid, "invalid base32z literal");
-        return {Base32z.decoded, Base32z.size};
+        requires(Base32z.valid)
+    constexpr std::span<const std::byte, Base32z.size> operator""_b32z_b() {
+        return std::span<const std::byte, Base32z.size>(Base32z.decoded, Base32z.size);
     }
 
     template <detail::u_b32z_literal Base32z>
-    constexpr std::span<const unsigned char> operator""_b32z_u() {
-        static_assert(Base32z.valid, "invalid base32z literal");
-        return {Base32z.decoded, Base32z.size};
+        requires(Base32z.valid)
+    constexpr std::span<const unsigned char, Base32z.size> operator""_b32z_u() {
+        return std::span<const unsigned char, Base32z.size>(Base32z.decoded, Base32z.size);
     }
 }  // namespace literals
 

--- a/oxenc/base64.h
+++ b/oxenc/base64.h
@@ -431,21 +431,23 @@ namespace detail {
 
 inline namespace literals {
     template <detail::c_b64_literal Base64>
+        requires(Base64.valid != 0)
     constexpr std::string_view operator""_b64() {
-        static_assert(Base64.valid, "Invalid base64 literal");
         return {Base64.decoded, Base64.size - Base64.valid};
     }
 
     template <detail::b_b64_literal Base64>
-    constexpr std::span<const std::byte> operator""_b64_b() {
-        static_assert(Base64.valid, "Invalid base64 literal");
-        return {Base64.decoded, Base64.size - Base64.valid};
+        requires(Base64.valid != 0)
+    constexpr std::span<const std::byte, Base64.size - Base64.valid> operator""_b64_b() {
+        return std::span<const std::byte, Base64.size - Base64.valid>(
+                Base64.decoded, Base64.size - Base64.valid);
     }
 
     template <detail::u_b64_literal Base64>
-    constexpr std::span<const unsigned char> operator""_b64_u() {
-        static_assert(Base64.valid, "Invalid base64 literal");
-        return {Base64.decoded, Base64.size - Base64.valid};
+        requires(Base64.valid != 0)
+    constexpr std::span<const unsigned char, Base64.size - Base64.valid> operator""_b64_u() {
+        return std::span<const unsigned char, Base64.size - Base64.valid>(
+                Base64.decoded, Base64.size - Base64.valid);
     }
 }  // namespace literals
 

--- a/oxenc/hex.h
+++ b/oxenc/hex.h
@@ -299,21 +299,21 @@ namespace detail {
 
 inline namespace literals {
     template <detail::c_hex_literal Hex>
+        requires(Hex.valid)
     constexpr std::string_view operator""_hex() {
-        static_assert(Hex.valid, "invalid hex literal");
         return {Hex.decoded, Hex.size};
     }
 
     template <detail::b_hex_literal Hex>
-    constexpr std::span<const std::byte> operator""_hex_b() {
-        static_assert(Hex.valid, "invalid hex literal");
-        return {Hex.decoded, Hex.size};
+        requires(Hex.valid)
+    constexpr std::span<const std::byte, Hex.size> operator""_hex_b() {
+        return std::span<const std::byte, Hex.size>(Hex.decoded, Hex.size);
     }
 
     template <detail::u_hex_literal Hex>
-    constexpr std::span<const unsigned char> operator""_hex_u() {
-        static_assert(Hex.valid, "invalid hex literal");
-        return {Hex.decoded, Hex.size};
+        requires(Hex.valid)
+    constexpr std::span<const unsigned char, Hex.size> operator""_hex_u() {
+        return std::span<const unsigned char, Hex.size>(Hex.decoded, Hex.size);
     }
 }  // namespace literals
 


### PR DESCRIPTION
The returned spans were dynamic extent, but can be fixed because we exactly know the decoded size at compile time.  This helps downstream in libsession-util where some new APIs are increasingly strict about the literals provided to them.

Additionally this changes the static_assert for validity to a C++20 requires, so that an invalid literals becomes a compilation failure at the source, rather than inside oxenc.